### PR TITLE
loaded fixtures

### DIFF
--- a/dataQueriesSQLite.sql
+++ b/dataQueriesSQLite.sql
@@ -1,0 +1,1 @@
+SELECT * FROM tunaapi_artist

--- a/tunaapi/fixtures/artists.json
+++ b/tunaapi/fixtures/artists.json
@@ -1,0 +1,11 @@
+[
+  {
+    "model": "tunaapi.artist",
+    "pk": 1,
+    "fields": {
+      "name": "Billy Joel",
+      "age": 76,
+      "bio": "William Martin Joel is an American singer, songwriter, and pianist. Nicknamed the Piano Man after his signature 1973 song of the same name, Joel has had a successful career as a solo artist since the 1970s"
+    }
+  }
+]

--- a/tunaapi/fixtures/genres.json
+++ b/tunaapi/fixtures/genres.json
@@ -1,0 +1,9 @@
+[
+  {
+    "model": "tunaapi.genre",
+    "pk": 1,
+    "fields": {
+      "description": "Pop Rock"
+    }
+  }
+]

--- a/tunaapi/fixtures/songs.json
+++ b/tunaapi/fixtures/songs.json
@@ -1,0 +1,12 @@
+[
+  {
+    "model": "tunaapi.song",
+    "pk": 1,
+    "fields": {
+      "title": "Vienna",
+      "artist": 1,
+      "album": 1,
+      "length": 214
+    }
+  }
+]


### PR DESCRIPTION
This pull request introduces new data fixtures for the `tunaapi` application and a query to retrieve artist data from the SQLite database. The changes primarily focus on adding sample data for testing and development purposes.

### Data Fixtures Added:

* [`tunaapi/fixtures/artists.json`](diffhunk://#diff-4c6ba51a65f61f4f42cf6dc1bc96c24eff35b1ecce8c5529a41a85cbf29caac5R1-R11): Added a fixture for an artist named Billy Joel, including details such as name, age, and biography.
* [`tunaapi/fixtures/genres.json`](diffhunk://#diff-30dab3a2864b8b5ee7f3aacd984645a3e769b2dd591c6cede640d3acb9fe49cfR1-R9): Added a fixture for the genre "Pop Rock" with a description field.
* [`tunaapi/fixtures/songs.json`](diffhunk://#diff-9e81486c5965f82d50ffb8dc634ef5c99b465100318c0f5059d12e553be120e4R1-R12): Added a fixture for the song "Vienna," including its title, associated artist, album, and length.

### Database Query:

* [`dataQueriesSQLite.sql`](diffhunk://#diff-ebdc83be0d74f3d45bcf16e10dc07c044b3289f484093b032bc1e2800fb0fc2fR1): Added a query to select all records from the `tunaapi_artist` table.