### PR TITLE
added urls, did list method for song, artist, and genre views

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = tunapiano.settings
+python_files = tests.py test_*.py *_tests.py

--- a/tunaapi/views/__init__.py
+++ b/tunaapi/views/__init__.py
@@ -1,0 +1,3 @@
+from .song import SongView
+from .genre import GenreView
+from .artist import ArtistView

--- a/tunaapi/views/artist.py
+++ b/tunaapi/views/artist.py
@@ -1,0 +1,27 @@
+"""View module for handling requests about artists"""
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers, status
+from tunaapi.models import Artist
+
+
+class ArtistView(ViewSet):
+    """Tuna artists view"""
+
+    def list(self, request):
+        """Handle GET requests to get all artists
+
+        Returns: 
+          Response -- JSON serialized list of artists
+        """
+        artists = Artist.objects.all()
+        serializer = AllArtistsSerializer(artists, many=True)
+        return Response(serializer.data)
+
+
+class AllArtistsSerializer(serializers.ModelSerializer):
+    """JSON Serializer for artists"""
+    class Meta:
+        model = Artist
+        fields = ('id', 'name', 'age', 'bio')

--- a/tunaapi/views/genre.py
+++ b/tunaapi/views/genre.py
@@ -1,0 +1,27 @@
+"""View module for handling requests about genres"""
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers, status
+from tunaapi.models import Genre
+
+
+class GenreView(ViewSet):
+    """Tuna genres view"""
+
+    def list(self, request):
+        """Handle GET requests to get all genres
+
+        Returns: 
+          Response -- JSON serialized list of genres
+        """
+        genres = Genre.objects.all()
+        serializer = AllGenresSerializer(genres, many=True)
+        return Response(serializer.data)
+
+
+class AllGenresSerializer(serializers.ModelSerializer):
+    """JSON Serializer for genres"""
+    class Meta:
+        model = Genre
+        fields = ('id', 'description')

--- a/tunaapi/views/song.py
+++ b/tunaapi/views/song.py
@@ -1,0 +1,29 @@
+"""View module for handling requests about songs"""
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers, status
+from tunaapi.models import Song
+
+
+class SongView(ViewSet):
+    """Tuna songs view"""
+
+    def list(self, request):
+        """Handle GET requests to get all songs
+
+        Returns: 
+          Response -- JSON serialized list of songs
+        """
+        songs = Song.objects.all()
+        serializer = AllSongsSerializer(songs, many=True)
+        return Response(serializer.data)
+
+    # TODO: within list method: this filter isn't required but i'm gonna do it for practice. FILTER SONGS BY ARTIST IF PROVIDED. see events view for help.
+
+
+class AllSongsSerializer(serializers.ModelSerializer):
+    """JSON Serializer for artists"""
+    class Meta:
+        model = Song
+        fields = ('id', 'title', 'artist_id', 'album', 'length')

--- a/tunapiano/urls.py
+++ b/tunapiano/urls.py
@@ -13,9 +13,25 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
+
 from django.contrib import admin
 from django.urls import path
+from django.conf.urls import include
+from rest_framework import routers
+from django.urls import path
+from tunaapi.views import SongView, GenreView, ArtistView
 
+
+# router.register variables: Used with viewsets to automatically generate multiple RESTful routes.
+router = routers.DefaultRouter(trailing_slash=False)
+router.register(r'songs', SongView, 'song')
+router.register(r'artists', ArtistView, 'artist')
+router.register(r'genres', GenreView, 'genre')
+
+# path(...): Used for explicitly defining a route to a view function or class.
 urlpatterns = [
     path('admin/', admin.site.urls),
+    # add router variables (above) to url patterns
+    path('', include(router.urls)),
 ]


### PR DESCRIPTION
This pull request introduces a set of changes to enhance the functionality of the `tunaapi` app by adding new view modules for handling `Artist`, `Genre`, and `Song` resources, along with corresponding serializers and routes. Additionally, it updates the test discovery configuration in `pytest.ini` to support more test file naming conventions.

### New Views and Serializers:

* **Artist View:**
  - Created `ArtistView` in `tunaapi/views/artist.py` to handle GET requests for all artists, returning JSON-serialized data.
  - Added `AllArtistsSerializer` to serialize `Artist` model fields: `id`, `name`, `age`, and `bio`.

* **Genre View:**
  - Created `GenreView` in `tunaapi/views/genre.py` to handle GET requests for all genres, returning JSON-serialized data.
  - Added `AllGenresSerializer` to serialize `Genre` model fields: `id` and `description`.

* **Song View:**
  - Created `SongView` in `tunaapi/views/song.py` to handle GET requests for all songs, returning JSON-serialized data.
  - Added `AllSongsSerializer` to serialize `Song` model fields: `id`, `title`, `artist_id`, `album`, and `length`.
  - Included a TODO comment for adding filtering functionality by artist.

### Routing Updates:

* Updated `tunapiano/urls.py`:
  - Registered RESTful routes for `songs`, `artists`, and `genres` using Django REST framework's `DefaultRouter`.
  - Included the router's URLs in the `urlpatterns`.

### Test Configuration:

* Updated `pytest.ini` to recognize additional test file naming patterns (`tests.py`, `test_*.py`, `*_tests.py`).