### PR TITLE
create methods in views for all entities

### DIFF
--- a/tunaapi/fixtures/songs.json
+++ b/tunaapi/fixtures/songs.json
@@ -5,7 +5,7 @@
     "fields": {
       "title": "Vienna",
       "artist": 1,
-      "album": 1,
+      "album": "The Stranger",
       "length": 214
     }
   }

--- a/tunaapi/views/artist.py
+++ b/tunaapi/views/artist.py
@@ -33,6 +33,15 @@ class ArtistView(ViewSet):
         except Artist.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
+    def create(self, request):
+        artist = Artist.objects.create(
+            name=request.data["name"],
+            age=request.data["age"],
+            bio=request.data["bio"]
+        )
+        serializer = AllArtistsSerializer(artist)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
 
 class AllArtistsSerializer(serializers.ModelSerializer):
     """JSON Serializer for artists"""

--- a/tunaapi/views/genre.py
+++ b/tunaapi/views/genre.py
@@ -33,6 +33,14 @@ class GenreView(ViewSet):
         except Genre.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
+    def create(self, request):
+        """ handle POST requests for gneres"""
+        genre = Genre.objects.create(
+            description=request.data["description"]
+        )
+        serializer = AllGenresSerializer(genre)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
 
 class AllGenresSerializer(serializers.ModelSerializer):
     """JSON Serializer for genres"""


### PR DESCRIPTION
This pull request introduces several changes to enhance the functionality of the `tunaapi` application. The most significant updates include adding `create` methods to allow POST requests for artists, genres, and songs, as well as updating the song fixture data to include album names. Additionally, minor adjustments to imports and comments were made to support these changes.

### New `create` methods for POST requests:
* Added a `create` method to the `ArtistViewSet` to handle POST requests for creating new artists. This method accepts `name`, `age`, and `bio` as input fields. (`tunaapi/views/artist.py`, [tunaapi/views/artist.pyR36-R44](diffhunk://#diff-2c30bb7df49431f564f80e5df1004eb9e698c60832e802ab2097162a3d928b51R36-R44))
* Added a `create` method to the `GenreViewSet` to handle POST requests for creating new genres. This method accepts a `description` field. (`tunaapi/views/genre.py`, [tunaapi/views/genre.pyR36-R43](diffhunk://#diff-b0afd34346b9fc682014bbfdf61ebf7347c6cd3ba2eb470a67fd7b4aaaa6654eR36-R43))
* Added a `create` method to the `SongViewSet` to handle POST requests for creating new songs. This method accepts `title`, `artist_id`, `album`, and `length` as input fields. (`tunaapi/views/song.py`, [tunaapi/views/song.pyR26-R46](diffhunk://#diff-b8cfcfa13eef2d4a871947ce0370bd84f3264c1068a95e3136063e02b039d9aaR26-R46))

### Updates to data fixtures:
* Updated the `album` field in the `songs.json` fixture to use the album name `"The Stranger"` instead of an album ID. (`tunaapi/fixtures/songs.json`, [tunaapi/fixtures/songs.jsonL8-R8](diffhunk://#diff-9e81486c5965f82d50ffb8dc634ef5c99b465100318c0f5059d12e553be120e4L8-R8))

### Minor code adjustments:
* Updated imports in `tunaapi/views/song.py` to include the `Artist` model, which is now required for the `create` method in the `SongViewSet`. (`tunaapi/views/song.py`, [tunaapi/views/song.pyL6-R6](diffhunk://#diff-b8cfcfa13eef2d4a871947ce0370bd84f3264c1068a95e3136063e02b039d9aaL6-R6))
* Added a docstring to the `retrieve` method in `SongViewSet` to describe its purpose. (`tunaapi/views/song.py`, [tunaapi/views/song.pyR26-R46](diffhunk://#diff-b8cfcfa13eef2d4a871947ce0370bd84f3264c1068a95e3136063e02b039d9aaR26-R46))