### PR TITLE
update methods in views for song, artist, and genre

### DIFF
--- a/tunaapi/views/artist.py
+++ b/tunaapi/views/artist.py
@@ -42,6 +42,17 @@ class ArtistView(ViewSet):
         serializer = AllArtistsSerializer(artist)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
+    def update(self, request, pk):
+        """ handle PUT requests for artists"""
+        artist = Artist.objects.get(pk=pk)
+        artist.name = request.data["name"]
+        artist.age = request.data["age"]
+        artist.bio = request.data["bio"]
+
+        artist.save()
+        serializer = AllArtistsSerializer(artist)
+        return Response(serializer.data)
+
 
 class AllArtistsSerializer(serializers.ModelSerializer):
     """JSON Serializer for artists"""

--- a/tunaapi/views/genre.py
+++ b/tunaapi/views/genre.py
@@ -41,6 +41,14 @@ class GenreView(ViewSet):
         serializer = AllGenresSerializer(genre)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
+    def update(self, request, pk):
+        """handle PUT requests for genres"""
+        genre = Genre.objects.get(pk=pk)
+        genre.description = request.data["description"]
+        genre.save()
+        serializer = AllGenresSerializer(genre)
+        return Response(serializer.data)
+
 
 class AllGenresSerializer(serializers.ModelSerializer):
     """JSON Serializer for genres"""

--- a/tunaapi/views/song.py
+++ b/tunaapi/views/song.py
@@ -44,6 +44,21 @@ class SongView(ViewSet):
         serializer = AllSongsSerializer(song)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
+    def update(self, request, pk):
+        """ handle put requests for songs"""
+
+        # artist = Artist.objects.get(pk=request.data["artist_id"])..... don't need this because ticket wants the id, not the obj
+        song = Song.objects.get(pk=pk)
+        song.title = request.data["title"]
+        # song.artist_id = artist.id
+        song.artist_id = request.data["artist_id"]
+        song.album = request.data["album"]
+        song.length = request.data["length"]
+
+        song.save()
+        serializer = AllSongsSerializer(song)
+        return Response(serializer.data)
+
 
 class AllSongsSerializer(serializers.ModelSerializer):
     """JSON Serializer for artists"""


### PR DESCRIPTION
This pull request introduces `update` methods to handle PUT requests for updating artists, genres, and songs in their respective views. These changes ensure that the API can modify existing records for these entities.

### New `update` methods for handling PUT requests:

* **Artists**: Added an `update` method in `tunaapi/views/artist.py` to update artist details such as `name`, `age`, and `bio`.
* **Genres**: Added an `update` method in `tunaapi/views/genre.py` to update the `description` field of a genre.
* **Songs**: Added an `update` method in `tunaapi/views/song.py` to update song details including `title`, `artist_id`, `album`, and `length`.